### PR TITLE
Update peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "author": "arnthor",
   "license": "ISC",
   "peerDependencies": {
-    "react": "^0.14.6",
-    "react-dom": "^0.14.6"
+    "react": "^0.14.6 || ^15.0.0-rc || ^15.0",
+    "react-dom": "^0.14.6 || ^15.0.0-rc || ^15.0"
   },
   "devDependencies": {
     "babel": "^6.3.26",


### PR DESCRIPTION
This fixes install issues with new versions of React and React DOM.

Here is the example output of the issue I had before making this change:

```
$ npm install react-bootstrap-toggle --save

npm WARN peerDependencies The peer dependency react@^0.14.6 included from react-bootstrap-toggle will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm WARN peerDependencies The peer dependency react-dom@^0.14.6 included from react-bootstrap-toggle will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm ERR! Linux 3.16.0-76-generic
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "react-bootstrap-toggle" "--save"
npm ERR! node v4.2.2
npm ERR! npm  v2.14.7
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package react@15.2.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-dom@15.2.0 wants react@^15.2.0
npm ERR! peerinvalid Peer react-redux@4.4.5 wants react@^0.14.0 || ^15.0.0-0
npm ERR! peerinvalid Peer react-router@2.5.2 wants react@^0.14.0 || ^15.0.0
npm ERR! peerinvalid Peer react-select@1.0.0-beta13 wants react@^0.14 || ^15.0.0-rc || ^15.0
npm ERR! peerinvalid Peer react-bootstrap-toggle@1.2.14 wants react@^0.14.6
```