### PR TITLE
Using PropTypes from package 'prop-types' instead of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "webpack-dev-server": "^2.3.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
   }

--- a/src/react-bootstrap-toggle.jsx
+++ b/src/react-bootstrap-toggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import * as util from './utils';
 
 const eitherStringOrInteger = PropTypes.oneOfType([


### PR DESCRIPTION
Fixes #13