### PR TITLE
Exclude dev files from publish

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["react", "es2015", "stage-0"],
+  "presets": ["react", "env", "stage-0"],
   "plugins": [ "transform-class-properties"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 dist
+/react-bootstrap-toggle-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,13 @@
 node_modules/
 coverage/
 examples/
+/.coveralls.yml
+/.eslintrc
+/.npmignore
+/.travis.yml
+/.babelrc
+/__test__
+/index.html
+/react-bootstrap-toggle-*.tgz
+/src
+/webpack.config.js

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "arnthor3/react-bootstrap-toggle"
   },
   "scripts": {
+    "prepublish": "npm run build && cp src/bootstrap2-toggle.css dist",
     "test": "jest",
     "test:watch": "jest --watch",
     "coverage": "jest --coverage",
@@ -28,7 +29,7 @@
     "babel-loader": "^6.2.8",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-runtime": "^6.23.0",


### PR DESCRIPTION
This is first work for #25 

I'm not sure what to do with the `coveralls` and `uglifyjs-folder` that are not part of the `devDependencies`.

Also had to make a manual copy of the CSS, which doesn't seem right.