### PR TITLE
Change Cursor on disabled toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 coverage/
 dist
 /react-bootstrap-toggle-*.tgz
+.DS_Store
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bootstrap-toggle",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A React version of the bootstrap-toggle without the JQuery dependency",
   "main": "./dist/index.js",
   "repository": {

--- a/src/bootstrap2-toggle.css
+++ b/src/bootstrap2-toggle.css
@@ -109,3 +109,6 @@ label.checkbox.inline .toggle {
 .slow .toggle-group { transition: left 0.7s; -webkit-transition: left 0.7s; }
 .fast .toggle-group { transition: left 0.1s; -webkit-transition: left 0.1s; }
 .quick .toggle-group { transition: none; -webkit-transition: none; }
+
+.toggle-on[disabled], .toggle-on.disabled { cursor: not-allowed!important }
+.toggle-off[disabled], .toggle-on.disabled { cursor: not-allowed!important }


### PR DESCRIPTION
In order to give a better UX, i want to use the cursor: not-allowed on disabled toggles.

Alternatively I could have add the class 'disabled' directly to toggle-on & toggle off but this would change the button text-color as well, so i preferred to override the { cursor: pointer } set by bootstrap global style with { cursor: not-allowed!important } on toggle-on & toggle-off when the element has an attribute "disabled" which is set by setting <Toggle {...} disabled/>